### PR TITLE
small refactor: switch to util.debugLog

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # debug-log2
 
-An environment based mini-lib to replace console.log in Node.js applications. Adds log context information automatically. Without the `DEBUG` environment variable, all logs are silent.
+Provides an alternative to [`util.debugLog`](https://nodejs.org/api/util.html#util_util_debuglog_section) with a simple stack trace, containing the filename, line number, and caller function.
+
+This is used to create a function which conditionally writes to stderr based on the existence of a `NODE_DEBUG` environment variable. If the section name appears in that environment variable, then the returned function will be similar to `console.error()`.
 
 ## Install
 
@@ -11,11 +13,9 @@ npm install --save debug-log2
 ## Usage
 
 ```js
-var debug = require('debug-log2')
+var debug = require('debug-log2')('foo')
 
-debug.enable()
-
-function _namedFunction(param){
+function _namedFunction (param) {
   debug('This is an example', param)
 }
 
@@ -26,14 +26,6 @@ _namedFunction(42)
 _namedFunction({param:'foo'})
 // app.js:6 in _namedFunction() This is an example { param: 'foo' }
 ```
-
-###`debug.enable()`
-
-This is a helper function so you do not need to set the environment variable prior to running your app. If this gets run, `process.env.DEBUG` will be set to true, and all debug logs will be printed to console.
-
-###`debug.disable()`
-
-This is a helper function to unset the debug variable. If this gets run, `process.env.DEBUG` will be set to false, and all debug logs will be ignored.
 
 ## LICENSE (ISC)
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Provides an alternative to [`util.debugLog`](https://nodejs.org/api/util.html#util_util_debuglog_section) with a simple stack trace, containing the filename, line number, and caller function.
 
-This is used to create a function which conditionally writes to stderr based on the existence of a `NODE_DEBUG` environment variable. If the section name appears in that environment variable, then the returned function will be similar to `console.error()`.
+This is used to create a function which conditionally writes to stderr based on the existence of a `NODE_DEBUG` environment variable. If the section name appears in that environment variable, then the returned function will be similar to `console.error()`. If not, then the returned function is a no-op.
 
 ## Install
 
@@ -26,6 +26,14 @@ _namedFunction(42)
 _namedFunction({param:'foo'})
 // app.js:6 in _namedFunction() This is an example { param: 'foo' }
 ```
+
+###`debug.enable()`
+
+This is a helper function so you do not need to set the environment variable prior to calling your debug function. If this gets run, `process.env.NODE_DEBUG` will be modified to add the approriate section, and all debug logs will be printed to console.
+
+###`debug.disable()`
+This is a helper function to unset the debug variable for the specific section. If this gets run, `process.env.NODE_DEBUG` will be modified to remove the specific section, and all debug logs will be ignored.
+
 
 ## LICENSE (ISC)
 

--- a/debug-log2.js
+++ b/debug-log2.js
@@ -11,43 +11,31 @@
 // WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
 // ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR
 // IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
-"use strict"
 
-var stackTrace = require('stack-trace')
-var colors = require('colors')
+'use strict'
+
+var chalk = require('chalk')
 var path = require('path')
+var stackTrace = require('stack-trace')
+var util = require('util')
 
-var debugRun = function(){
-  var log = function _log() {
-    if (toBool(process.env.DEBUG)) {
-      var args, file, frame, line, method
-      args = arguments.length >= 1 ? [].slice.call(arguments, 0) : []
+module.exports = function debugRun (section) {
+  var debug = util.debuglog(section)
 
-      frame = stackTrace.get()[1]
-      file = path.basename(frame.getFileName())
-      line = frame.getLineNumber()
-      method = frame.getFunctionName()
+  return function _log () {
+    // convert to real array
+    var args = Array.prototype.slice.call(arguments)
 
-      args.unshift("" + file + ":" + line + " in " + method + "()")
-      args[0] = args[0].grey
-      console.log.apply(console, args)
-      return args
-    }
-    return false
-  }
-  log['toggle'] = function _toggle (){
-    process.env.DEBUG = !toBool(process.env.DEBUG)
-  }
-  log['enable'] = function _enable (){
-    process.env.DEBUG = true
-  }
-  log['disable'] = function _disable (){
-    process.env.DEBUG = false
-  }
-  return log
-}
-module.exports = debugRun()
+    var callSite = stackTrace.get()[1]
+    var file = path.basename(callSite.getFileName())
+    var line = callSite.getLineNumber()
+    var method = callSite.getFunctionName()
 
-function toBool(val){
-  return val === 'true'
+    // construct stack trace line
+    args.unshift(chalk.grey(util.format('%s:%s in %s()', file, line, method)))
+
+    debug.apply(util, args)
+
+    return args
+  }
 }

--- a/package.json
+++ b/package.json
@@ -10,9 +10,6 @@
     "type": "git",
     "url": "https://github.com/therebelrobot/debug-log2.git"
   },
-  "engines": {
-    "node": ">=0.11.3"
-  },
   "keywords": [
     "log",
     "debug",

--- a/package.json
+++ b/package.json
@@ -10,6 +10,9 @@
     "type": "git",
     "url": "https://github.com/therebelrobot/debug-log2.git"
   },
+  "engines": {
+    "node": ">=0.11.3"
+  },
   "keywords": [
     "log",
     "debug",
@@ -27,11 +30,10 @@
   "devDependencies": {
     "chai": "^2.2.0",
     "istanbul": "^0.3.13",
-    "mocha": "^2.2.4",
-    "standard": "^3.6.1"
+    "mocha": "^2.2.4"
   },
   "dependencies": {
-    "colors": "^1.0.3",
+    "chalk": "^1.0.0",
     "stack-trace": "0.0.9"
   }
 }

--- a/test/debug-log2.test.js
+++ b/test/debug-log2.test.js
@@ -1,120 +1,78 @@
+/* global describe, it */
+
 var expect = require('chai').expect
-var debug = require('../debug-log2')
+var debug = require('../debug-log2')('test')
 
 describe('debug-log2', function () {
-  it('should return a function', function _debugReturnFunction(done) {
+  it('should return a function', function _debugReturnFunction (done) {
     expect(debug).to.be.a('function')
     done()
   })
-  it('should return file position if empty', function _debugReturnFunction(done) {
-    debug.enable()
+
+  it('should return file position if empty', function _debugReturnFunction (done) {
     var returns = debug()
     expect(returns).to.be.an('array')
     expect(returns.length).to.equal(1)
     done()
   })
-  it('should return filename', function _debugReturnFilename(done) {
-    debug.enable()
+
+  it('should return filename', function _debugReturnFilename (done) {
     var returns = debug('Hello')[0].split('\u001b[90m')[1].split('\u001b[39m')[0]
     var filename = returns.split(':')[0]
     expect(filename).to.be.a('string')
     expect(filename).to.equal('debug-log2.test.js')
     done()
   })
-  it('should return function name', function _debugReturnFunctionName(done) {
-    debug.enable()
+
+  it('should return function name', function _debugReturnFunctionName (done) {
     var returns = debug('Hello')[0].split('\u001b[90m')[1].split('\u001b[39m')[0]
     var funcName = returns.split(' ')
-    funcName = funcName[funcName.length-1]
+    funcName = funcName[funcName.length - 1]
     expect(funcName).to.be.a('string')
     expect(funcName).to.equal('_debugReturnFunctionName()')
     done()
   })
-  it('should return line number', function _debugReturnLineNumber(done) {
-    debug.enable()
+
+  it('should return line number', function _debugReturnLineNumber (done) {
     var returns = debug('Hello')[0].split('\u001b[90m')[1].split('\u001b[39m')[0]
     var filename = returns.split(':')[1].split(' ')[0]
     expect(filename).to.be.a('string')
-    expect(filename).to.equal('35')
+    expect(filename).to.equal('37')
     done()
   })
-  it('should return a string parameter', function _debugReturnStringParam(done) {
-    debug.enable()
+
+  it('should return a string parameter', function _debugReturnStringParam (done) {
     var returns = debug('Hello')[1]
     expect(returns).to.be.a('string')
     expect(returns).to.equal('Hello')
     done()
   })
-  it('should return a number parameter', function _debugReturnNumberParam(done) {
-    debug.enable()
+
+  it('should return a number parameter', function _debugReturnNumberParam (done) {
     var returns = debug(45)[1]
     expect(returns).to.be.a('number')
     expect(returns).to.equal(45)
     done()
   })
-  it('should return an array parameter', function _debugReturnArrayParam(done) {
-    debug.enable()
-    var returns = debug(["foo","bar"])[1]
+
+  it('should return an array parameter', function _debugReturnArrayParam (done) {
+    var returns = debug(['foo', 'bar'])[1]
     expect(returns).to.be.an('array')
-    expect(returns).to.deep.equal(["foo","bar"])
+    expect(returns).to.deep.equal(['foo', 'bar'])
     done()
   })
-  it('should return an object parameter', function _debugReturnObjectParam(done) {
-    debug.enable()
-    var returns = debug({foo:'bar'})[1]
+
+  it('should return an object parameter', function _debugReturnObjectParam (done) {
+    var returns = debug({foo: 'bar'})[1]
     expect(returns).to.be.an('object')
-    expect(returns).to.deep.equal({foo:"bar"})
+    expect(returns).to.deep.equal({foo: 'bar'})
     done()
   })
-  it('should return an multiple parameters', function _debugReturnMultipleParams(done) {
-    debug.enable()
+
+  it('should return an multiple parameters', function _debugReturnMultipleParams (done) {
     var returns = debug(45, 'hello')
-    returns.shift();
+    returns.shift()
     expect(returns.length).to.be.above(1)
     done()
-  })
-  it('should return false if DEBUG variable is not set in environment', function _debugNoDEBUG(done) {
-    debug.disable()
-    var returns = debug('false hello')
-    expect(returns).to.be.false
-    done()
-  })
-  describe('enable', function() {
-    it('should return a function', function _debugOnReturnFunction(done) {
-      expect(debug.enable).to.be.a('function')
-      done()
-    })
-    it('should turn on DEBUG environment variable', function _debugOnFunctions(done) {
-      debug.enable()
-      debug(process.env.DEBUG)
-      expect(process.env.DEBUG).to.equal('true')
-      done()
-    })
-  })
-  describe('disable', function() {
-    it('should return a function', function _debugOffReturnFunction(done) {
-      expect(debug.disable).to.be.a('function')
-      done()
-    })
-    it('should turn disable DEBUG environment variable', function _debugOffFunctions(done) {
-      debug.disable()
-      expect(process.env.DEBUG).to.equal('false')
-      done()
-    })
-  })
-  describe('toggle', function() {
-    it('should return a function', function _debugToggleReturnFunction(done) {
-      expect(debug.toggle).to.be.a('function')
-      done()
-    })
-    it('should toggle DEBUG environment variable', function _debugToggleFunctions(done) {
-      debug.disable()
-      expect(process.env.DEBUG).to.equal('false')
-      debug.toggle()
-      expect(process.env.DEBUG).to.equal('true')
-      debug.toggle()
-      expect(process.env.DEBUG).to.equal('false')
-      done()
-    })
   })
 })

--- a/test/debug-log2.test.js
+++ b/test/debug-log2.test.js
@@ -5,11 +5,13 @@ var debug = require('../debug-log2')('test')
 
 describe('debug-log2', function () {
   it('should return a function', function _debugReturnFunction (done) {
+    debug.enable()
     expect(debug).to.be.a('function')
     done()
   })
 
   it('should return file position if empty', function _debugReturnFunction (done) {
+    debug.enable()
     var returns = debug()
     expect(returns).to.be.an('array')
     expect(returns.length).to.equal(1)
@@ -17,6 +19,7 @@ describe('debug-log2', function () {
   })
 
   it('should return filename', function _debugReturnFilename (done) {
+    debug.enable()
     var returns = debug('Hello')[0].split('\u001b[90m')[1].split('\u001b[39m')[0]
     var filename = returns.split(':')[0]
     expect(filename).to.be.a('string')
@@ -25,6 +28,7 @@ describe('debug-log2', function () {
   })
 
   it('should return function name', function _debugReturnFunctionName (done) {
+    debug.enable()
     var returns = debug('Hello')[0].split('\u001b[90m')[1].split('\u001b[39m')[0]
     var funcName = returns.split(' ')
     funcName = funcName[funcName.length - 1]
@@ -34,14 +38,16 @@ describe('debug-log2', function () {
   })
 
   it('should return line number', function _debugReturnLineNumber (done) {
+    debug.enable()
     var returns = debug('Hello')[0].split('\u001b[90m')[1].split('\u001b[39m')[0]
     var filename = returns.split(':')[1].split(' ')[0]
     expect(filename).to.be.a('string')
-    expect(filename).to.equal('37')
+    expect(filename).to.equal('42')
     done()
   })
 
   it('should return a string parameter', function _debugReturnStringParam (done) {
+    debug.enable()
     var returns = debug('Hello')[1]
     expect(returns).to.be.a('string')
     expect(returns).to.equal('Hello')
@@ -49,6 +55,7 @@ describe('debug-log2', function () {
   })
 
   it('should return a number parameter', function _debugReturnNumberParam (done) {
+    debug.enable()
     var returns = debug(45)[1]
     expect(returns).to.be.a('number')
     expect(returns).to.equal(45)
@@ -56,6 +63,7 @@ describe('debug-log2', function () {
   })
 
   it('should return an array parameter', function _debugReturnArrayParam (done) {
+    debug.enable()
     var returns = debug(['foo', 'bar'])[1]
     expect(returns).to.be.an('array')
     expect(returns).to.deep.equal(['foo', 'bar'])
@@ -63,6 +71,7 @@ describe('debug-log2', function () {
   })
 
   it('should return an object parameter', function _debugReturnObjectParam (done) {
+    debug.enable()
     var returns = debug({foo: 'bar'})[1]
     expect(returns).to.be.an('object')
     expect(returns).to.deep.equal({foo: 'bar'})
@@ -70,9 +79,63 @@ describe('debug-log2', function () {
   })
 
   it('should return an multiple parameters', function _debugReturnMultipleParams (done) {
+    debug.enable()
     var returns = debug(45, 'hello')
     returns.shift()
     expect(returns.length).to.be.above(1)
     done()
+  })
+
+  it('should return false if NODE_DEBUG variable is not set in environment', function _debugNoDEBUG (done) {
+    debug.disable()
+    var returns = debug('false hello')
+    expect(returns).to.be.false
+    done()
+  })
+
+  describe('enable', function () {
+    it('should return a function', function _debugOnReturnFunction (done) {
+      expect(debug.enable).to.be.a('function')
+      done()
+    })
+
+    it('should turn on NODE_DEBUG environment variable', function _debugOnFunctions (done) {
+      debug.enable()
+      expect(process.env.NODE_DEBUG).to.match(/\bTEST\b/g)
+      done()
+    })
+  })
+
+  describe('disable', function () {
+    it('should return a function', function _debugOffReturnFunction (done) {
+      expect(debug.disable).to.be.a('function')
+      done()
+    })
+
+    it('should turn disable NODE_DEBUG environment variable', function _debugOffFunctions (done) {
+      debug.enable()
+      debug.disable()
+      expect(process.env.NODE_DEBUG).to.not.match(/\bTEST\b/g)
+      done()
+    })
+  })
+
+  describe('toggle', function () {
+    it('should return a function', function _debugToggleReturnFunction (done) {
+      expect(debug.toggle).to.be.a('function')
+      done()
+    })
+
+    it('should toggle NODE_DEBUG environment variable', function _debugToggleFunctions (done) {
+      debug.enable()
+      expect(process.env.NODE_DEBUG).to.match(/\bTEST\b/g)
+
+      debug.toggle()
+      expect(process.env.NODE_DEBUG).to.not.match(/\bTEST\b/g)
+
+      debug.toggle()
+      expect(process.env.NODE_DEBUG).to.match(/\bTEST\b/g)
+      done()
+    })
   })
 })


### PR DESCRIPTION
- added `section` parameter as per `util.debugLog` requirement
- switched to [`chalk`](https://www.npmjs.com/package/chalk) instead of [`color`](https://www.npmjs.com/package/color) to avoid extending `String.prototype`
- use `Array.prototype.slice.call` to convert function `arguments` to a real array
- removed `standard` from `devDependencies` _(wasn't being used, plz add back when used)_
- updated `README` with appropriate language reflecting changes in API
